### PR TITLE
What if Maybe was lazy?

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ However, if you initialize Maybe lazily, we do not know the type before the lazy
 Maybe { "I'm lazy" }                => #<Maybe:0x0000010107a600 @lazy=#<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x0000010107a768>:each>>>
 ```
 
+This feature needs Ruby version >= 2.0.0.
+
 ## Examples
 
 Instead of using if-clauses to define whether a value is a `nil`, you can wrap the value with `Maybe()` and threat it the same way whether or not it is a `nil`

--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -39,7 +39,11 @@ class Maybe
   # rubocop:enable PredicateName
 
   def lazy
-    Maybe.new(__enumerable_value.lazy)
+    if [].respond_to?(:lazy)
+      Maybe.new(__enumerable_value.lazy)
+    else
+      self
+    end
   end
 
   private
@@ -159,9 +163,10 @@ end
 
 # rubocop:disable MethodName
 def Maybe(value = nil, &block)
-  if block
+  if block && [].respond_to?(:lazy)
     Maybe.from_block(&block)
   else
+    value = block.call if block
     if value.nil? || (value.respond_to?(:length) && value.length == 0)
       None()
     else

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -184,8 +184,8 @@ describe "possibly" do
         v * v
       end
 
-      expect(init_called).to eql(false)
-      expect(map_called).to eql(false)
+      expect(init_called).to eql(lazy_enabled ? false : true)
+      expect(map_called).to eql(lazy_enabled ? false : true)
       expect(m.get).to eql(4)
       expect(init_called).to eql(true)
       expect(map_called).to eql(true)
@@ -199,13 +199,13 @@ describe "possibly" do
         v * v
       end
 
-      expect(map_called).to eql(false)
+      expect(map_called).to eql(lazy_enabled ? false : true)
       expect(m.get).to eql(4)
       expect(map_called).to eql(true)
     end
   end
 
-  def factors(num)
-    Maybe((2..num - 1).select { |n| num % n == 0 })
+  def lazy_enabled
+    @lazy_enabled ||= [].respond_to?(:lazy)
   end
 end


### PR DESCRIPTION
This is an opt-in implementation for laziness. By default Maybes are not lazy, but if you call `lazy` or initialize Maybe with a block, it becomes lazy.

From README:
## Laziness

Ruby 2.0 introduced lazy enumerables. By calling `lazy` on any enumerable, you get the lazy version of it. Same goes with Maybe.

``` ruby

called = false
m = Maybe(2).lazy.map do |value|
  called = true;
  value * value;
end

puts called # => false
puts m.get # => 4 # Map is called now
puts called # => true
```

You can also initialize Maybe lazily by giving it a block.

``` ruby
initialization_block_called = false
map_called = false

m = Maybe do
  initialization_block_called = true
  do_some_expensive_calculation              # returns 1234567890
end.map do |value|
  map_called = true;
  "the value of expensive calculation: #{value}";
end

puts initialization_block_called # => false
puts map_called # => false
puts m.get # => "the value of expensive calculation: 1234567890 # Map is called now
puts initialization_block_called # => true
puts map_called # => true
```

Note that if you initialize a maybe non-lazily and inspect it, you see from the class that it is a Some:

``` ruby
Maybe("I'm not lazy")               => #<Some:0x007ff7ac8697b8 @value=2>
```

However, if you initialize Maybe lazily, we do not know the type before the lazy block is evaluated. Thus, you see a different output when printing the value

``` ruby
Maybe { "I'm lazy" }               => #<Maybe:0x0000010107a600 @lazy=#<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x0000010107a768>:each>>>
```
