### PR TITLE
`or_else` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ when None
 end
 ```
 
+## or_else
+
+`or_else` returns the current `Maybe` if it's a `Some`, but if it's a `None`, it returns the parameter that was given to it (which should be a `Maybe`).
+
+Here's an example: Show "title", which is person's job title or degree if she doesn't have a job or "Unknown" if both are missing.
+
+```ruby
+maybe_person = Maybe(person)
+
+title = maybe_person.job.title.or_else { maybe_person.degree }.get_or_else { "Unknown" }
+
+title = if person && person.job && person.job.title.present?
+  person.job.title
+elsif person && person.degree.present?
+  person.degree
+else
+  "Unknown"
+end
+```
+
 ## Examples
 
 Instead of using if-clauses to define whether a value is a `nil`, you can wrap the value with `Maybe()` and threat it the same way whether or not it is a `nil`

--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -31,6 +31,10 @@ class Some < Maybe
     @value
   end
 
+  def or_else(*)
+    self
+  end
+
   # rubocop:disable PredicateName
   def is_some?
     true
@@ -69,6 +73,10 @@ class None < Maybe
 
   def get_or_else(els = nil)
     block_given? ? yield : els
+  end
+
+  def or_else(els = nil, &block)
+    block ? block.call : els
   end
 
   # rubocop:disable PredicateName

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -150,6 +150,29 @@ describe "possibly" do
     end
   end
 
+  describe "or_else" do
+    it "returns self if it's a Some" do
+      current = Maybe(true)
+      other = Maybe(true)
+
+      expect(current.or_else(other)).to equal current
+    end
+
+    it "returns other if it's a Some" do
+      current = Maybe(nil)
+      other = Maybe(true)
+
+      expect(current.or_else(other)).to equal other
+    end
+
+    it "takes also a block" do
+      current = Maybe(true)
+      other = Maybe(true)
+
+      expect(current.or_else { other }).to equal current
+    end
+  end
+
   describe "forward" do
     it "forwards methods" do
       expect(Some("maybe").upcase.get).to eql("MAYBE")


### PR DESCRIPTION
## or_else

`or_else` returns the current `Maybe` if it's a `Some`, but if it's a `None`, it returns the parameter that was given to it (which should be a `Maybe`).

Here's an example: Show "title", which is person's job title or degree if she doesn't have a job or "Unknown" if both are missing.

``` ruby
maybe_person = Maybe(person)

title = maybe_person.job.title.or_else { maybe_person.degree }.get_or_else { "Unknown" }

title = if person && person.job && person.job.title.present?
  person.job.title
elsif person && person.degree.present?
  person.degree
else
  "Unknown"
end
```
