### PR TITLE
Adjust Some(nil) to return None() so that "surprising" nils don't emerge...

### DIFF
--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -23,10 +23,6 @@ end
 
 # Represents a non-empty value
 class Some < Maybe
-  def self.new(value)
-    super
-  end
-
   def initialize(value)
     @value = value
   end

--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -15,10 +15,18 @@ class Maybe
     other.class == self.class
   end
   alias_method :eql?, :==
+
+  def self.empty_value?(value)
+    value.nil? || (value.respond_to?(:length) && value.length == 0)
+  end
 end
 
 # Represents a non-empty value
 class Some < Maybe
+  def self.new(value)
+    super
+  end
+
   def initialize(value)
     @value = value
   end
@@ -94,15 +102,11 @@ end
 
 # rubocop:disable MethodName
 def Maybe(value)
-  if value.nil? || (value.respond_to?(:length) && value.length == 0)
-    None()
-  else
-    Some(value)
-  end
+  Maybe.empty_value?(value) ? None() : Some.new(value)
 end
 
 def Some(value)
-  Some.new(value)
+  Maybe(value)
 end
 
 def None

--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -45,6 +45,20 @@ class Some < Maybe
   end
   # rubocop:enable PredicateName
 
+  def join
+    @value.is_a?(Maybe) ? @value : self
+  end
+
+  def join!
+    if @value.is_a?(Some)
+      @value.join!
+    elsif @value.is_a?(None)
+      @value
+    else
+      self
+    end
+  end
+
   def ==(other)
     super && get == other.get
   end
@@ -84,6 +98,14 @@ class None < Maybe
     true
   end
   # rubocop:enable PredicateName
+
+  def join
+    self
+  end
+
+  def join!
+    self
+  end
 
   def method_missing(*)
     self

--- a/lib/possibly.rb
+++ b/lib/possibly.rb
@@ -69,6 +69,10 @@ class Some < Maybe
   end
 
   def method_missing(method_sym, *args, &block)
+    if method_sym[0] == '_'
+      method_sym = method_sym.slice(1, method_sym.length)
+    end
+
     map { |value| value.send(method_sym, *args, &block) }
   end
 
@@ -98,14 +102,6 @@ class None < Maybe
     true
   end
   # rubocop:enable PredicateName
-
-  def join
-    self
-  end
-
-  def join!
-    self
-  end
 
   def method_missing(*)
     self

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -36,6 +36,37 @@ describe "possibly" do
     end
   end
 
+  context "joining nested monads" do
+    let(:nested_none) { Maybe(None()) }
+    let(:nested_some) { Maybe(Some(10)) }
+    let(:deep_none) { Maybe(nested_none) }
+    let(:deep_some) { Maybe(nested_some) }
+
+    describe "#join" do
+      it "joins a nested none into its parent" do
+        expect(nested_none.join.is_none?).to eql(true)
+      end
+
+      it "joins a nested some into its parent" do
+        expect(nested_some.join.get).to eql(10)
+      end
+
+      it "does not join recursively" do
+        expect(deep_some.join.join.get).to eql(10)
+      end
+    end
+
+    describe "#join!" do
+      it "joins all Some instances recursively" do
+        expect(nested_some.join!.get).to eql(10)
+      end
+
+      it "joins all None instances recursively" do
+        expect(nested_none.join!.is_none?).to be_true
+      end
+    end
+  end
+
   describe "values and non-values" do
     it "None" do
       expect(Maybe(nil).is_none?).to eql(true)

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -188,4 +188,20 @@ describe "possibly" do
       expect(Some([1, 2, 3]).map { |arr| arr.map { |v| v * v } }.get).to eql([1, 4, 9])
     end
   end
+
+  describe "underscore methods" do
+    let(:some_array) { Some([1, 2, 3, 4]) }
+
+    it "applies methods that have equivalents in Maybe to the wrapped value" do
+      expect(some_array._map { |n| n ** 2 }).to eq(Some([1, 4, 9, 16]))
+    end
+
+    it "applies methods without equivalents in Maybe to the wrapped value" do
+      expect(Some("abc")._upcase).to eq(Some("ABC"))
+    end
+
+    it "works with Nones" do
+      expect(None()._something.is_none?).to be_true
+    end
+  end
 end

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -53,6 +53,7 @@ describe "possibly" do
 
   describe "is_a" do
     it "Some" do
+      expect(Some(nil).is_a?(None)).to eql(true)
       expect(Some(1).is_a?(Some)).to eql(true)
       expect(Some(1).is_a?(None)).to eql(false)
       expect(None().is_a?(Some)).to eql(false)


### PR DESCRIPTION
I noticed that I had a NPE despite having things wrapped in the monad, and discovered that `Some(nil)` actually returns a `Some` value. The cause is the absence of a test for "empty" values in the `Some` constructor. This adjustment makes `Some()` and `Maybe()` functionally equivalent, and probably has a small impact on performance; but I think the semantic improvement is significant.